### PR TITLE
CLI browser-SSO authorize page

### DIFF
--- a/src/apis/inference/sdk.gen.ts
+++ b/src/apis/inference/sdk.gen.ts
@@ -35,6 +35,9 @@ import type {
 	ExchangeCodeAuthExchangePostData,
 	ExchangeCodeAuthExchangePostResponses,
 	ExchangeCodeAuthExchangePostErrors,
+	CliCodeAuthCliCodePostData,
+	CliCodeAuthCliCodePostResponses,
+	CliCodeAuthCliCodePostErrors,
 	RefreshTokensAuthRefreshPostData,
 	RefreshTokensAuthRefreshPostResponses,
 	RefreshTokensAuthRefreshPostErrors,
@@ -77,6 +80,12 @@ import type {
 	GetChatApiKeyApiKeysChatGetData,
 	GetChatApiKeyApiKeysChatGetResponses,
 	GetChatApiKeyApiKeysChatGetErrors,
+	GetCliApiKeysApiKeysCliGetData,
+	GetCliApiKeysApiKeysCliGetResponses,
+	GetCliApiKeysApiKeysCliGetErrors,
+	CreateCliApiKeyApiKeysCliPostData,
+	CreateCliApiKeyApiKeysCliPostResponses,
+	CreateCliApiKeyApiKeysCliPostErrors,
 	DeleteApiKeyApiKeysKeyIdDeleteData,
 	DeleteApiKeyApiKeysKeyIdDeleteResponses,
 	DeleteApiKeyApiKeysKeyIdDeleteErrors,
@@ -417,6 +426,31 @@ export const exchangeCodeAuthExchangePost = <ThrowOnError extends boolean = fals
 };
 
 /**
+ * Cli Code
+ * Mint a one-time, PKCE-bound code for the CLI loopback flow.
+ *
+ * Called by the console SPA once the user is authenticated (by any method). The code is
+ * bound to the supplied PKCE challenge and exchanged by the CLI at /auth/exchange.
+ */
+export const cliCodeAuthCliCodePost = <ThrowOnError extends boolean = false>(
+	options: Options<CliCodeAuthCliCodePostData, ThrowOnError>,
+) => {
+	return (options.client ?? _heyApiClient).post<
+		CliCodeAuthCliCodePostResponses,
+		CliCodeAuthCliCodePostErrors,
+		ThrowOnError
+	>({
+		responseType: "json",
+		url: "/auth/cli/code",
+		...options,
+		headers: {
+			"Content-Type": "application/json",
+			...options.headers,
+		},
+	});
+};
+
+/**
  * Refresh Tokens
  * Rotate a refresh token (one-time use per token) and return a fresh pair.
  */
@@ -706,6 +740,48 @@ export const getChatApiKeyApiKeysChatGet = <ThrowOnError extends boolean = false
 		responseType: "json",
 		url: "/api-keys/chat",
 		...options,
+	});
+};
+
+/**
+ * Get Cli Api Keys
+ */
+export const getCliApiKeysApiKeysCliGet = <ThrowOnError extends boolean = false>(
+	options?: Options<GetCliApiKeysApiKeysCliGetData, ThrowOnError>,
+) => {
+	return (options?.client ?? _heyApiClient).get<
+		GetCliApiKeysApiKeysCliGetResponses,
+		GetCliApiKeysApiKeysCliGetErrors,
+		ThrowOnError
+	>({
+		responseType: "json",
+		url: "/api-keys/cli",
+		...options,
+	});
+};
+
+/**
+ * Create Cli Api Key
+ * Mint (or rotate in place) the CLI API key for the caller's device.
+ *
+ * Final step of the CLI browser-SSO login: the CLI calls this with the freshly
+ * exchanged session token. Returns the full key once (stored by the CLI).
+ */
+export const createCliApiKeyApiKeysCliPost = <ThrowOnError extends boolean = false>(
+	options: Options<CreateCliApiKeyApiKeysCliPostData, ThrowOnError>,
+) => {
+	return (options.client ?? _heyApiClient).post<
+		CreateCliApiKeyApiKeysCliPostResponses,
+		CreateCliApiKeyApiKeysCliPostErrors,
+		ThrowOnError
+	>({
+		responseType: "json",
+		url: "/api-keys/cli",
+		...options,
+		headers: {
+			"Content-Type": "application/json",
+			...options.headers,
+		},
 	});
 };
 

--- a/src/apis/inference/types.gen.ts
+++ b/src/apis/inference/types.gen.ts
@@ -37,6 +37,10 @@ export type ApiKey = {
 	 */
 	monthly_limit?: number | null;
 	type: ApiKeyType;
+	/**
+	 * Expires At
+	 */
+	expires_at?: string | null;
 };
 
 /**
@@ -76,7 +80,7 @@ export type ApiKeyListResponse = {
 /**
  * ApiKeyType
  */
-export type ApiKeyType = "api" | "chat" | "liberclaw" | "x402";
+export type ApiKeyType = "api" | "chat" | "liberclaw" | "x402" | "cli";
 
 /**
  * ApiKeyUpdate
@@ -276,6 +280,36 @@ export type CheckoutResponse = {
 };
 
 /**
+ * CliApiKeyCreate
+ */
+export type CliApiKeyCreate = {
+	/**
+	 * Host
+	 */
+	host?: string | null;
+};
+
+/**
+ * CliCodeRequest
+ */
+export type CliCodeRequest = {
+	/**
+	 * Challenge
+	 */
+	challenge: string;
+};
+
+/**
+ * CliCodeResponse
+ */
+export type CliCodeResponse = {
+	/**
+	 * Code
+	 */
+	code: string;
+};
+
+/**
  * CreditBalanceResponse
  */
 export type CreditBalanceResponse = {
@@ -468,6 +502,10 @@ export type ExchangeRequest = {
 	 * Code
 	 */
 	code: string;
+	/**
+	 * Verifier
+	 */
+	verifier?: string | null;
 };
 
 /**
@@ -543,6 +581,10 @@ export type FullApiKey = {
 	 */
 	monthly_limit?: number | null;
 	type: ApiKeyType;
+	/**
+	 * Expires At
+	 */
+	expires_at?: string | null;
 	/**
 	 * Full Key
 	 */
@@ -1740,6 +1782,37 @@ export type ExchangeCodeAuthExchangePostResponses = {
 export type ExchangeCodeAuthExchangePostResponse =
 	ExchangeCodeAuthExchangePostResponses[keyof ExchangeCodeAuthExchangePostResponses];
 
+export type CliCodeAuthCliCodePostData = {
+	body: CliCodeRequest;
+	headers?: {
+		/**
+		 * Authorization
+		 */
+		authorization?: string | null;
+	};
+	path?: never;
+	query?: never;
+	url: "/auth/cli/code";
+};
+
+export type CliCodeAuthCliCodePostErrors = {
+	/**
+	 * Validation Error
+	 */
+	422: HttpValidationError;
+};
+
+export type CliCodeAuthCliCodePostError = CliCodeAuthCliCodePostErrors[keyof CliCodeAuthCliCodePostErrors];
+
+export type CliCodeAuthCliCodePostResponses = {
+	/**
+	 * Successful Response
+	 */
+	200: CliCodeResponse;
+};
+
+export type CliCodeAuthCliCodePostResponse = CliCodeAuthCliCodePostResponses[keyof CliCodeAuthCliCodePostResponses];
+
 export type RefreshTokensAuthRefreshPostData = {
 	body: RefreshRequest;
 	path?: never;
@@ -2166,6 +2239,72 @@ export type GetChatApiKeyApiKeysChatGetResponses = {
 
 export type GetChatApiKeyApiKeysChatGetResponse =
 	GetChatApiKeyApiKeysChatGetResponses[keyof GetChatApiKeyApiKeysChatGetResponses];
+
+export type GetCliApiKeysApiKeysCliGetData = {
+	body?: never;
+	headers?: {
+		/**
+		 * Authorization
+		 */
+		authorization?: string | null;
+	};
+	path?: never;
+	query?: never;
+	url: "/api-keys/cli";
+};
+
+export type GetCliApiKeysApiKeysCliGetErrors = {
+	/**
+	 * Validation Error
+	 */
+	422: HttpValidationError;
+};
+
+export type GetCliApiKeysApiKeysCliGetError = GetCliApiKeysApiKeysCliGetErrors[keyof GetCliApiKeysApiKeysCliGetErrors];
+
+export type GetCliApiKeysApiKeysCliGetResponses = {
+	/**
+	 * Response Get Cli Api Keys Api Keys Cli Get
+	 * Successful Response
+	 */
+	200: Array<ApiKey>;
+};
+
+export type GetCliApiKeysApiKeysCliGetResponse =
+	GetCliApiKeysApiKeysCliGetResponses[keyof GetCliApiKeysApiKeysCliGetResponses];
+
+export type CreateCliApiKeyApiKeysCliPostData = {
+	body: CliApiKeyCreate;
+	headers?: {
+		/**
+		 * Authorization
+		 */
+		authorization?: string | null;
+	};
+	path?: never;
+	query?: never;
+	url: "/api-keys/cli";
+};
+
+export type CreateCliApiKeyApiKeysCliPostErrors = {
+	/**
+	 * Validation Error
+	 */
+	422: HttpValidationError;
+};
+
+export type CreateCliApiKeyApiKeysCliPostError =
+	CreateCliApiKeyApiKeysCliPostErrors[keyof CreateCliApiKeyApiKeysCliPostErrors];
+
+export type CreateCliApiKeyApiKeysCliPostResponses = {
+	/**
+	 * Successful Response
+	 */
+	200: FullApiKey;
+};
+
+export type CreateCliApiKeyApiKeysCliPostResponse =
+	CreateCliApiKeyApiKeysCliPostResponses[keyof CreateCliApiKeyApiKeysCliPostResponses];
 
 export type DeleteApiKeyApiKeysKeyIdDeleteData = {
 	body?: never;

--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -10,7 +10,9 @@ import WalletConnectButtons from "@/components/WalletConnectButtons";
 // Google/GitHub OAuth is hidden for now (only email + wallets). Flip to re-enable.
 const SHOW_OAUTH = false;
 
-export default function LoginPanel() {
+// `onSuccess` overrides the default post-login redirect (used by the CLI authorize page,
+// which stays on /cli to show the approve step instead of navigating to the dashboard).
+export default function LoginPanel({ onSuccess }: { onSuccess?: () => void } = {}) {
 	const loginWithEmail = useAccountStore((state) => state.loginWithEmail);
 	const verifyEmailCode = useAccountStore((state) => state.verifyEmailCode);
 	const loginWithOAuth = useAccountStore((state) => state.loginWithOAuth);
@@ -36,7 +38,10 @@ export default function LoginPanel() {
 		setLoading(true);
 		const ok = await verifyEmailCode(email, code);
 		setLoading(false);
-		if (ok) navigate({ to: "/dashboard" });
+		if (ok) {
+			if (onSuccess) onSuccess();
+			else navigate({ to: "/dashboard" });
+		}
 	};
 
 	return (

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as UsageRouteImport } from './routes/usage'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ImagesRouteImport } from './routes/images'
 import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as CliRouteImport } from './routes/cli'
 import { Route as BillingRouteImport } from './routes/billing'
 import { Route as ApiKeysRouteImport } from './routes/api-keys'
 import { Route as IndexRouteImport } from './routes/index'
@@ -37,6 +38,11 @@ const ImagesRoute = ImagesRouteImport.update({
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CliRoute = CliRouteImport.update({
+  id: '/cli',
+  path: '/cli',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BillingRoute = BillingRouteImport.update({
@@ -69,6 +75,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/api-keys': typeof ApiKeysRoute
   '/billing': typeof BillingRoute
+  '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
   '/images': typeof ImagesRoute
   '/login': typeof LoginRoute
@@ -80,6 +87,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/api-keys': typeof ApiKeysRoute
   '/billing': typeof BillingRoute
+  '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
   '/images': typeof ImagesRoute
   '/login': typeof LoginRoute
@@ -92,6 +100,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/api-keys': typeof ApiKeysRoute
   '/billing': typeof BillingRoute
+  '/cli': typeof CliRoute
   '/dashboard': typeof DashboardRoute
   '/images': typeof ImagesRoute
   '/login': typeof LoginRoute
@@ -105,6 +114,7 @@ export interface FileRouteTypes {
     | '/'
     | '/api-keys'
     | '/billing'
+    | '/cli'
     | '/dashboard'
     | '/images'
     | '/login'
@@ -116,6 +126,7 @@ export interface FileRouteTypes {
     | '/'
     | '/api-keys'
     | '/billing'
+    | '/cli'
     | '/dashboard'
     | '/images'
     | '/login'
@@ -127,6 +138,7 @@ export interface FileRouteTypes {
     | '/'
     | '/api-keys'
     | '/billing'
+    | '/cli'
     | '/dashboard'
     | '/images'
     | '/login'
@@ -139,6 +151,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ApiKeysRoute: typeof ApiKeysRoute
   BillingRoute: typeof BillingRoute
+  CliRoute: typeof CliRoute
   DashboardRoute: typeof DashboardRoute
   ImagesRoute: typeof ImagesRoute
   LoginRoute: typeof LoginRoute
@@ -175,6 +188,13 @@ declare module '@tanstack/react-router' {
       path: '/dashboard'
       fullPath: '/dashboard'
       preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cli': {
+      id: '/cli'
+      path: '/cli'
+      fullPath: '/cli'
+      preLoaderRoute: typeof CliRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/billing': {
@@ -219,6 +239,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ApiKeysRoute: ApiKeysRoute,
   BillingRoute: BillingRoute,
+  CliRoute: CliRoute,
   DashboardRoute: DashboardRoute,
   ImagesRoute: ImagesRoute,
   LoginRoute: LoginRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,7 +23,7 @@ const developersSidebarItems = [
 ];
 
 // Routes rendered standalone, without the app sidebar/header chrome.
-const CHROMELESS_ROUTES = ["/login", "/auth/callback", "/auth/verify"];
+const CHROMELESS_ROUTES = ["/login", "/auth/callback", "/auth/verify", "/cli"];
 
 function RootComponent() {
 	const pathname = useRouterState({ select: (state) => state.location.pathname });

--- a/src/routes/cli.tsx
+++ b/src/routes/cli.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
-import { Loader2, TerminalSquare } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { cliCodeAuthCliCodePost } from "@/apis/inference/sdk.gen";
 import { useAccountStore } from "@/stores/account";
 import { Button } from "@/components/ui/button";
@@ -62,40 +62,33 @@ function CliAuthorize() {
 	};
 
 	return (
-		<div className="container mx-auto flex min-h-screen max-w-md flex-col items-center justify-center px-4 py-12 text-center">
+		<div className="container mx-auto flex min-h-screen max-w-sm flex-col items-center justify-center px-4 py-12 text-center">
 			<div className="mb-6 flex flex-col items-center gap-3">
-				<div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-					<TerminalSquare className="h-6 w-6 text-primary" />
-				</div>
+				<img src="/favicon.ico" alt="LibertAI" className="h-14 w-14 rounded-2xl shadow-sm" />
 				<h1 className="text-xl font-semibold">Authorize the LibertAI CLI</h1>
 			</div>
 
 			{!paramsValid ? (
-				<p className="text-muted-foreground">
-					This authorization link is invalid or incomplete. Run <code>libertai login</code> again from your
-					terminal.
+				<p className="text-sm text-muted-foreground">
+					This link is invalid. Run <code>libertai login</code> again.
 				</p>
 			) : !isAuthenticated ? (
 				<div className="w-full space-y-4">
-					<p className="text-sm text-muted-foreground">Sign in to connect your terminal to LibertAI.</p>
+					<p className="text-sm text-muted-foreground">Sign in to connect your terminal.</p>
 					{/* Stay on /cli after sign-in; the page reacts to isAuthenticated and shows Approve. */}
 					<div className="flex justify-center">
 						<LoginPanel onSuccess={() => {}} />
 					</div>
 				</div>
 			) : (
-				<div className="w-full space-y-4">
-					<p className="text-muted-foreground">
-						A device wants to sign in to LibertAI as you and create a CLI API key on this machine.
-					</p>
+				<div className="w-full space-y-3">
+					<p className="text-sm text-muted-foreground">Connect this device to your account.</p>
 					{error && <p className="text-sm text-destructive">{error}</p>}
 					<Button className="w-full" onClick={handleApprove} disabled={submitting}>
 						{submitting && <Loader2 className="h-4 w-4 animate-spin" />}
-						Authorize this device
+						Authorize
 					</Button>
-					<p className="text-xs text-muted-foreground">
-						Only approve this if you just started <code>libertai login</code> yourself.
-					</p>
+					<p className="text-xs text-muted-foreground">Only continue if you started this from your terminal.</p>
 				</div>
 			)}
 		</div>

--- a/src/routes/cli.tsx
+++ b/src/routes/cli.tsx
@@ -1,0 +1,115 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMemo, useState } from "react";
+import { Loader2, TerminalSquare } from "lucide-react";
+import { cliCodeAuthCliCodePost } from "@/apis/inference/sdk.gen";
+import { useAccountStore } from "@/stores/account";
+import { Button } from "@/components/ui/button";
+import LoginPanel from "@/components/LoginPanel";
+
+export const Route = createFileRoute("/cli")({
+	component: CliAuthorize,
+});
+
+// Only loopback redirect targets are accepted — the one-time code must come back to a
+// local CLI server on this machine, never to an arbitrary host (defends against a crafted
+// /cli link phishing a logged-in user's code).
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+
+function parseRedirectUri(raw: string | null): URL | null {
+	if (!raw) return null;
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		return null;
+	}
+	if (url.protocol !== "http:") return null;
+	if (!LOOPBACK_HOSTS.has(url.hostname)) return null;
+	return url;
+}
+
+function CliAuthorize() {
+	const isAuthenticated = useAccountStore((state) => state.isAuthenticated);
+
+	const { redirectUri, state, challenge } = useMemo(() => {
+		const params = new URLSearchParams(window.location.search);
+		return {
+			redirectUri: parseRedirectUri(params.get("redirect_uri")),
+			state: params.get("state") ?? "",
+			challenge: params.get("challenge") ?? "",
+		};
+	}, []);
+
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const paramsValid = redirectUri !== null && state !== "" && challenge !== "";
+
+	const handleApprove = async () => {
+		if (!redirectUri) return;
+		setSubmitting(true);
+		setError(null);
+		const response = await createCliCode(challenge);
+		if (!response) {
+			setSubmitting(false);
+			setError("Could not authorize the CLI. Please try again.");
+			return;
+		}
+		// Hand the one-time code back to the CLI's local loopback server.
+		redirectUri.searchParams.set("code", response);
+		redirectUri.searchParams.set("state", state);
+		window.location.href = redirectUri.toString();
+	};
+
+	return (
+		<div className="container mx-auto flex min-h-screen max-w-md flex-col items-center justify-center px-4 py-12 text-center">
+			<div className="mb-6 flex flex-col items-center gap-3">
+				<div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+					<TerminalSquare className="h-6 w-6 text-primary" />
+				</div>
+				<h1 className="text-xl font-semibold">Authorize the LibertAI CLI</h1>
+			</div>
+
+			{!paramsValid ? (
+				<p className="text-muted-foreground">
+					This authorization link is invalid or incomplete. Run <code>libertai login</code> again from your
+					terminal.
+				</p>
+			) : !isAuthenticated ? (
+				<div className="w-full space-y-4">
+					<p className="text-sm text-muted-foreground">Sign in to connect your terminal to LibertAI.</p>
+					{/* Stay on /cli after sign-in; the page reacts to isAuthenticated and shows Approve. */}
+					<div className="flex justify-center">
+						<LoginPanel onSuccess={() => {}} />
+					</div>
+				</div>
+			) : (
+				<div className="w-full space-y-4">
+					<p className="text-muted-foreground">
+						A device wants to sign in to LibertAI as you and create a CLI API key on this machine.
+					</p>
+					{error && <p className="text-sm text-destructive">{error}</p>}
+					<Button className="w-full" onClick={handleApprove} disabled={submitting}>
+						{submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+						Authorize this device
+					</Button>
+					<p className="text-xs text-muted-foreground">
+						Only approve this if you just started <code>libertai login</code> yourself.
+					</p>
+				</div>
+			)}
+		</div>
+	);
+}
+
+/** Mint a PKCE-bound one-time code for the CLI; returns the code or null on failure.
+ * Auth (Bearer token or wallet cookie) is attached by the shared inference client. */
+async function createCliCode(challenge: string): Promise<string | null> {
+	try {
+		const response = await cliCodeAuthCliCodePost({ body: { challenge } });
+		if (response.error) return null;
+		return response.data?.code ?? null;
+	} catch {
+		return null;
+	}
+}

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -18,7 +18,8 @@ function LoginPage() {
 	return (
 		<div className="container mx-auto flex min-h-[80vh] flex-col items-center justify-center px-4 py-12">
 			<div className="w-full max-w-sm space-y-6">
-				<div className="space-y-2 text-center">
+				<div className="flex flex-col items-center space-y-3 text-center">
+					<img src="/favicon.ico" alt="LibertAI" className="h-14 w-14 rounded-2xl shadow-sm" />
 					<h1 className="text-2xl font-bold">Sign in to LibertAI</h1>
 					<p className="text-sm text-muted-foreground">Use your email, a social account, or a wallet.</p>
 				</div>


### PR DESCRIPTION
Adds the `/cli` page used by the CLI's browser login.

- `/cli`: validates the loopback redirect, lets the user sign in (any method), then on **Authorize** mints a PKCE-bound code and redirects back to the CLI's local server
- `LoginPanel`: optional `onSuccess` so `/cli` stays put after sign-in
- LibertAI logo on the sign-in screen; concise copy on the authorize page
- regenerated inference SDK

Depends on libertai-inference#47.