### PR TITLE
Design pass: unified dark surfaces, control consistency, bug fixes

### DIFF
--- a/src/components/404.tsx
+++ b/src/components/404.tsx
@@ -6,7 +6,7 @@ export const NotFoundPage = () => {
 		<div className="container flex flex-col items-center justify-center min-h-[80vh] max-w-md text-center mx-auto px-4 py-16">
 			<div className="space-y-6">
 				<div className="space-y-2">
-					<h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl text-primary">404</h1>
+					<h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl text-primary-text">404</h1>
 					<h2 className="text-2xl font-bold tracking-tight">Page not found</h2>
 					<p className="text-muted-foreground">
 						We couldn't find the page you're looking for. The page may have been moved or deleted.

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -41,12 +41,12 @@ function SidebarMenuItemWithAutoClose({
 
 	return (
 		<SidebarMenuItem>
-			<Link to={to} onClick={handleClick} disabled={isActive}>
-				<SidebarMenuButton tooltip={tooltip} isActive={isActive}>
+			<SidebarMenuButton asChild tooltip={tooltip} isActive={isActive}>
+				<Link to={to} onClick={handleClick} disabled={isActive}>
 					{icon}
 					<span>{label}</span>
-				</SidebarMenuButton>
-			</Link>
+				</Link>
+			</SidebarMenuButton>
 		</SidebarMenuItem>
 	);
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -55,7 +55,13 @@ type SidebarItem = {
 	to: string;
 	icon: ReactNode;
 	label: string;
+	// Extra paths that should also highlight this item (e.g. sibling routes under the same section).
+	activePaths?: string[];
 };
+
+function isPathActive(currentPath: string, path: string): boolean {
+	return currentPath === path || currentPath.startsWith(path + "/");
+}
 
 export function Layout({
 	children,
@@ -109,7 +115,7 @@ export function Layout({
 								<SidebarMenuItemWithAutoClose
 									to={item.to}
 									tooltip={item.label}
-									isActive={currentPath === item.to || currentPath.startsWith(item.to + "/")}
+									isActive={[item.to, ...(item.activePaths ?? [])].some((path) => isPathActive(currentPath, path))}
 									icon={item.icon}
 									label={item.label}
 									key={item.to}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -22,12 +22,14 @@ function SidebarMenuItemWithAutoClose({
 	to,
 	tooltip,
 	isActive,
+	disabled,
 	icon,
 	label,
 }: Readonly<{
 	to: string;
 	tooltip: string;
 	isActive: boolean;
+	disabled: boolean;
 	icon: ReactNode;
 	label: string;
 }>) {
@@ -42,7 +44,7 @@ function SidebarMenuItemWithAutoClose({
 	return (
 		<SidebarMenuItem>
 			<SidebarMenuButton asChild tooltip={tooltip} isActive={isActive}>
-				<Link to={to} onClick={handleClick} disabled={isActive}>
+				<Link to={to} onClick={handleClick} disabled={disabled}>
 					{icon}
 					<span>{label}</span>
 				</Link>
@@ -116,6 +118,7 @@ export function Layout({
 									to={item.to}
 									tooltip={item.label}
 									isActive={[item.to, ...(item.activePaths ?? [])].some((path) => isPathActive(currentPath, path))}
+									disabled={isPathActive(currentPath, item.to)}
 									icon={item.icon}
 									label={item.label}
 									key={item.to}

--- a/src/hooks/data/use-api-keys.ts
+++ b/src/hooks/data/use-api-keys.ts
@@ -6,26 +6,19 @@ import {
 	deleteApiKeyApiKeysKeyIdDelete,
 	getApiKeysApiKeysGet,
 	updateApiKeyApiKeysKeyIdPut,
-	ValidationError,
 } from "@libertai/inference-sdk";
 import { useAccountStore } from "@libertai/auth";
 
-// Helper function to extract FastAPI error details
-const extractFastAPIError = (error?: ValidationError[] | string | undefined): string => {
-	// Check for simple error message in detail field
-	if (error && typeof error === "string") {
-		return error;
+// Maps an HTTP status to user-facing copy. Never surfaces raw backend `detail` text —
+// FastAPI validation/DB error messages aren't meant for end users.
+const extractFastAPIError = (status?: number): string => {
+	if (status === 400 || status === 409) {
+		return "A key with this name already exists.";
 	}
-
-	// FastAPI validation errors are in detail array
-	if (Array.isArray(error)) {
-		const details: ValidationError[] = error;
-		// Get the first error message or join multiple messages
-		if (details.length > 0) {
-			return details.map((d) => d.msg).join(", ");
-		}
+	if (status === 422) {
+		return "That input isn't valid.";
 	}
-	return "An unknown error occurred";
+	return "Something went wrong. Try again.";
 };
 
 export function useApiKeys() {
@@ -39,7 +32,7 @@ export function useApiKeys() {
 			const response = await getApiKeysApiKeysGet();
 
 			if (response.error) {
-				throw new Error(extractFastAPIError(response.error.detail));
+				throw new Error(extractFastAPIError(response.status));
 			}
 
 			return response.data;
@@ -55,7 +48,7 @@ export function useApiKeys() {
 			});
 
 			if (response.error) {
-				throw new Error(extractFastAPIError(response.error.detail));
+				throw new Error(extractFastAPIError(response.status));
 			}
 
 			return response.data;
@@ -96,7 +89,7 @@ export function useApiKeys() {
 			});
 
 			if (response.error) {
-				throw new Error(extractFastAPIError(response.error.detail));
+				throw new Error(extractFastAPIError(response.status));
 			}
 
 			return response.data;
@@ -122,7 +115,7 @@ export function useApiKeys() {
 			});
 
 			if (response.error) {
-				throw new Error(extractFastAPIError(response.error.detail));
+				throw new Error(extractFastAPIError(response.status));
 			}
 
 			return true;

--- a/src/hooks/data/use-api-keys.ts
+++ b/src/hooks/data/use-api-keys.ts
@@ -12,10 +12,10 @@ import { useAccountStore } from "@libertai/auth";
 // Maps an HTTP status to user-facing copy. Never surfaces raw backend `detail` text —
 // FastAPI validation/DB error messages aren't meant for end users.
 const extractFastAPIError = (status?: number): string => {
-	if (status === 400 || status === 409) {
+	if (status === 409) {
 		return "A key with this name already exists.";
 	}
-	if (status === 422) {
+	if (status === 400 || status === 422) {
 		return "That input isn't valid.";
 	}
 	return "Something went wrong. Try again.";

--- a/src/lib/route-titles.ts
+++ b/src/lib/route-titles.ts
@@ -1,5 +1,4 @@
-// Single source for route labels — feeds both the document <title> (via each route's
-// `head` option) and the desktop header's current-page label in Layout.tsx.
+// Single source for route labels — feeds the document <title> via each route's `head` option.
 export const ROUTE_TITLES: Record<string, string> = {
 	"/": "Dashboard",
 	"/api-keys": "API keys",

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,7 +8,12 @@ const developersSidebarItems = [
 	{ to: "/images", icon: <Image className="h-4 w-4" />, label: "Images" },
 	{ to: "/api-keys", icon: <Key className="h-4 w-4" />, label: "API keys" },
 	{ to: "/usage", icon: <LineChart className="h-4 w-4" />, label: "Usage" },
-	{ to: "/billing", icon: <CreditCard className="h-4 w-4" />, label: "Billing" },
+	{
+		to: "/billing",
+		icon: <CreditCard className="h-4 w-4" />,
+		label: "Billing",
+		activePaths: ["/plans", "/top-up"],
+	},
 ];
 
 // Routes rendered standalone, without the app sidebar/header chrome.

--- a/src/routes/api-keys.tsx
+++ b/src/routes/api-keys.tsx
@@ -469,14 +469,14 @@ function ApiKeys() {
 						<div className="space-y-2">
 							<Label htmlFor="model-select">Model</Label>
 							{isErrorModels ? (
-								<div className="flex items-center gap-3">
+								<div id="model-select" className="flex items-center gap-3">
 									<p className="text-sm text-muted-foreground">Couldn't load models.</p>
 									<Button variant="outline" size="sm" onClick={() => refetchModels()}>
 										Retry
 									</Button>
 								</div>
 							) : isLoadingModels ? (
-								<Skeleton className="h-9 w-full max-w-xs" />
+								<Skeleton id="model-select" className="h-9 w-full max-w-xs" />
 							) : (
 								<Select value={selectedModel ?? ""} onValueChange={setSelectedModel}>
 									<SelectTrigger id="model-select" className="w-full max-w-xs">
@@ -527,7 +527,7 @@ function ApiKeys() {
 							For more detailed instructions and example code in various programming languages, see our{" "}
 							<a
 								href="https://docs.libertai.io/apis/text"
-								className="text-primary hover:underline"
+								className="text-primary-text hover:underline"
 								target="_blank"
 								rel="noopener noreferrer"
 							>

--- a/src/routes/api-keys.tsx
+++ b/src/routes/api-keys.tsx
@@ -174,6 +174,8 @@ function ApiKeys() {
 	const [selectedModel, setSelectedModel] = useState<string | null>(null);
 	const [activeLang, setActiveLang] = useState<CodeLang>("curl");
 	const [keyPendingDelete, setKeyPendingDelete] = useState<ApiKey | null>(null);
+	// Survives the dialog's close animation so the description doesn't flash "undefined" while it fades out.
+	const [deleteTargetName, setDeleteTargetName] = useState<string | null>(null);
 
 	// Fetch available text models from Aleph
 	const {
@@ -198,7 +200,17 @@ function ApiKeys() {
 	const { isAuthenticated, isPending } = useRequireAuth();
 
 	// Use API keys query hook
-	const { apiKeys, isLoading, isError, refetch, createApiKey, updateApiKey, deleteApiKey } = useApiKeys();
+	const {
+		apiKeys,
+		isLoading,
+		isError,
+		refetch,
+		createApiKey,
+		updateApiKey,
+		deleteApiKey,
+		createApiKeyStatus,
+		updateApiKeyStatus,
+	} = useApiKeys();
 
 	// Rolling 30-day usage stats
 	const endDate = dayjs().format("YYYY-MM-DD");
@@ -390,7 +402,9 @@ function ApiKeys() {
 								) : (
 									sortedApiKeys.map((key) => (
 										<TableRow key={key.id}>
-											<TableCell className="font-medium">{key.name}</TableCell>
+											<TableCell className="font-medium max-w-[28ch] truncate" title={key.name}>
+												{key.name}
+											</TableCell>
 											<TableCell className="font-mono">{key.key}</TableCell>
 											<TableCell className="text-muted-foreground">
 												{dayjs(key.created_at).format("YYYY-MM-DD")}
@@ -426,8 +440,12 @@ function ApiKeys() {
 														</DropdownMenuItem>
 														<DropdownMenuSeparator />
 														<DropdownMenuItem
-															onClick={() => setKeyPendingDelete(key)}
-															className="cursor-pointer text-destructive"
+															onClick={() => {
+																setKeyPendingDelete(key);
+																setDeleteTargetName(key.name);
+															}}
+															variant="destructive"
+															className="cursor-pointer"
 														>
 															<Trash className="h-4 w-4 mr-2" />
 															<span>Delete</span>
@@ -576,7 +594,7 @@ function ApiKeys() {
 								mode="create"
 								onSubmit={handleCreateKey}
 								onCancel={() => setShowNewKeyModal(false)}
-								isLoading={isLoading}
+								isLoading={createApiKeyStatus === "pending"}
 							/>
 						</>
 					) : (
@@ -602,7 +620,7 @@ function ApiKeys() {
 										size="icon"
 										onClick={() => setShowKey(!showKey)}
 										className="ml-2"
-										aria-label="Show key"
+										aria-label={showKey ? "Hide key" : "Show key"}
 									>
 										{showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
 									</Button>
@@ -638,7 +656,7 @@ function ApiKeys() {
 							onSubmit={handleUpdateKey}
 							onCancel={() => setShowEditModal(false)}
 							initialData={currentKey}
-							isLoading={isLoading}
+							isLoading={updateApiKeyStatus === "pending"}
 						/>
 					)}
 				</DialogContent>
@@ -648,7 +666,7 @@ function ApiKeys() {
 				open={!!keyPendingDelete}
 				onOpenChange={(open) => !open && setKeyPendingDelete(null)}
 				title="Delete API key"
-				description={`"${keyPendingDelete?.name}" will stop working immediately. This can't be undone.`}
+				description={`"${deleteTargetName}" will stop working immediately. This can't be undone.`}
 				confirmLabel="Delete key"
 				destructive
 				onConfirm={() => keyPendingDelete && handleDeleteKey(keyPendingDelete.id)}

--- a/src/routes/auth.callback.tsx
+++ b/src/routes/auth.callback.tsx
@@ -38,7 +38,7 @@ function AuthCallback() {
 				<div className="space-y-4">
 					<p className="text-lg font-medium">Sign-in failed</p>
 					<p className="text-muted-foreground">This sign-in link is invalid or has expired.</p>
-					<Button onClick={() => navigate({ to: "/" })}>Back to sign in</Button>
+					<Button onClick={() => navigate({ to: "/login" })}>Back to sign in</Button>
 				</div>
 			) : (
 				<div className="flex items-center gap-3 text-muted-foreground">

--- a/src/routes/images.tsx
+++ b/src/routes/images.tsx
@@ -12,6 +12,7 @@ import { Card, CardHeader } from "@libertai/ui/card";
 import { Textarea } from "@libertai/ui/textarea";
 import { Label } from "@libertai/ui/label";
 import { PageSkeleton } from "@libertai/ui/page-skeleton";
+import { ToggleGroup } from "@libertai/ui/toggle-group";
 import { routeHead } from "@/lib/route-titles";
 
 export const Route = createFileRoute("/images")({
@@ -226,22 +227,15 @@ function Images() {
 						{/* Endpoint Selector */}
 						<Card>
 							<CardHeader title="API endpoint" icon={<Globe className="h-5 w-5 text-primary" />} />
-							<div className="flex gap-1 rounded-lg border border-border bg-card p-1">
-								<Button
-									variant={endpoint === "sdapi" ? "default" : "ghost"}
-									onClick={() => setEndpoint("sdapi")}
-									className="flex-1"
-								>
-									Stable Diffusion (sdapi)
-								</Button>
-								<Button
-									variant={endpoint === "openai" ? "default" : "ghost"}
-									onClick={() => setEndpoint("openai")}
-									className="flex-1"
-								>
-									OpenAI-compatible
-								</Button>
-							</div>
+							<ToggleGroup
+								value={endpoint}
+								onValueChange={(value) => setEndpoint(value as EndpointType)}
+								className="w-full"
+								options={[
+									{ value: "sdapi", label: "Stable Diffusion (sdapi)" },
+									{ value: "openai", label: "OpenAI-compatible" },
+								]}
+							/>
 							<p className="text-xs text-muted-foreground mt-3">
 								{endpoint === "sdapi"
 									? "POST https://api.libertai.io/sdapi/v1/txt2img"
@@ -254,9 +248,9 @@ function Images() {
 							<div className="space-y-2">
 								<Label htmlFor="api-key-select">API key</Label>
 								{isLoadingKeys ? (
-									<Skeleton className="h-10 w-full" />
+									<Skeleton id="api-key-select" className="h-10 w-full" />
 								) : apiKeys.length === 0 ? (
-									<div className="bg-amber-500/10 text-amber-500 p-4 rounded-md">
+									<div id="api-key-select" className="bg-amber-500/10 text-amber-500 p-4 rounded-md">
 										<p className="text-sm">
 											No API keys found.{" "}
 											<Link to="/api-keys" className="underline font-medium">
@@ -287,14 +281,14 @@ function Images() {
 							<div className="space-y-2">
 								<Label htmlFor="model-select">Model</Label>
 								{isErrorModels ? (
-									<div className="flex items-center gap-3">
+									<div id="model-select" className="flex items-center gap-3">
 										<p className="text-sm text-muted-foreground">Couldn't load models.</p>
 										<Button variant="outline" size="sm" onClick={() => refetchModels()}>
 											Retry
 										</Button>
 									</div>
 								) : isLoadingModels ? (
-									<Skeleton className="h-10 w-full" />
+									<Skeleton id="model-select" className="h-10 w-full" />
 								) : models && models.length > 0 ? (
 									<>
 										<Select value={selectedModel || ""} onValueChange={setSelectedModel}>
@@ -318,7 +312,9 @@ function Images() {
 										)}
 									</>
 								) : (
-									<p className="text-sm text-muted-foreground">No image models available</p>
+									<p id="model-select" className="text-sm text-muted-foreground">
+										No image models available
+									</p>
 								)}
 							</div>
 						</Card>
@@ -341,7 +337,7 @@ function Images() {
 										href="https://docs.libertai.io/apis/image"
 										target="_blank"
 										rel="noopener noreferrer"
-										className="text-primary hover:underline"
+										className="text-primary-text hover:underline"
 									>
 										API docs
 									</a>{" "}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -25,7 +25,7 @@ function LandingPage() {
 	const navigate = useNavigate();
 
 	return (
-		<div className="mx-auto max-w-6xl px-4 py-16 lg:py-24">
+		<div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-6xl items-center px-4 py-16">
 			<div className="grid gap-12 lg:grid-cols-[1fr_1.15fr] lg:items-center">
 				<div className="space-y-6">
 					<div className="space-y-2">
@@ -61,13 +61,13 @@ function LandingPage() {
 						</li>
 					</ul>
 				</div>
-				<Card className="bg-zinc-950 border-zinc-800 p-0 overflow-hidden">
-					<div className="flex items-center gap-1.5 px-4 py-3 border-b border-zinc-800">
-						<span className="h-3 w-3 rounded-full bg-zinc-700" />
-						<span className="h-3 w-3 rounded-full bg-zinc-700" />
-						<span className="h-3 w-3 rounded-full bg-zinc-700" />
+				<Card className="bg-zinc-950 dark:bg-secondary border-zinc-800 dark:border-border p-0 overflow-hidden">
+					<div className="flex items-center gap-1.5 px-4 py-3 border-b border-zinc-800 dark:border-border">
+						<span className="h-3 w-3 rounded-full bg-zinc-700 dark:bg-hover" />
+						<span className="h-3 w-3 rounded-full bg-zinc-700 dark:bg-hover" />
+						<span className="h-3 w-3 rounded-full bg-zinc-700 dark:bg-hover" />
 					</div>
-					<pre className="p-4 text-sm text-zinc-100 font-mono overflow-x-auto">{`curl https://api.libertai.io/v1/chat/completions \\
+					<pre className="p-4 text-sm text-zinc-100 dark:text-foreground font-mono overflow-x-auto">{`curl https://api.libertai.io/v1/chat/completions \\
   -H "Authorization: Bearer $LIBERTAI_API_KEY" \\
   -d '{
     "model": "glm-5.2",
@@ -82,7 +82,7 @@ function LandingPage() {
 function DashboardPage() {
 	const navigate = useNavigate();
 	const { formattedCredits, isLoading: areCreditsLoading, isError: isCreditsError } = useCredits();
-	const { apiKeys, isLoading: areApiKeysLoading } = useApiKeys();
+	const { apiKeys, isLoading: areApiKeysLoading, isError: isApiKeysError } = useApiKeys();
 	const {
 		apiCalls,
 		tokensUsed,
@@ -138,14 +138,20 @@ function DashboardPage() {
 						title="API calls"
 						icon={<Zap className="h-5 w-5 text-primary" />}
 						isLoading={areStatsLoading}
-						value={formatCompactNumber(apiCalls)}
+						value={isStatsError ? <span title="Couldn't load">—</span> : formatCompactNumber(apiCalls)}
 						footer="This month"
 					/>
 					<StatCard
 						title="Active keys"
 						icon={<Key className="h-5 w-5 text-primary" />}
 						isLoading={areApiKeysLoading}
-						value={apiKeys.filter((key) => key.is_active).length}
+						value={
+							isApiKeysError ? (
+								<span title="Couldn't load">—</span>
+							) : (
+								apiKeys.filter((key) => key.is_active).length
+							)
+						}
 						action={
 							<Button size="sm" variant="outline" onClick={() => navigate({ to: "/api-keys" })}>
 								Manage
@@ -156,7 +162,7 @@ function DashboardPage() {
 						title="Tokens used"
 						icon={<LineChart className="h-5 w-5 text-primary" />}
 						isLoading={areStatsLoading}
-						value={formatCompactNumber(tokensUsed)}
+						value={isStatsError ? <span title="Couldn't load">—</span> : formatCompactNumber(tokensUsed)}
 						footer="This month"
 					/>
 				</div>
@@ -166,7 +172,7 @@ function DashboardPage() {
 						<CardHeader title="Usage trends" icon={<BarChart4 className="h-5 w-5 text-primary" />} />
 
 						{isStatsError ? (
-							<ErrorCard message="Couldn't load usage stats." onRetry={refetchStats} />
+							<ErrorCard plain message="Couldn't load usage stats." onRetry={refetchStats} />
 						) : (
 							<div className="h-64">
 								{areStatsLoading ? (

--- a/src/routes/usage.tsx
+++ b/src/routes/usage.tsx
@@ -191,6 +191,10 @@ function AdvancedView() {
 	}, [timeRange]);
 
 	const handleExportData = () => {
+		// No per-day Cost column: the API only returns an aggregate cost for the range, not
+		// per-day (daily_usage/DailyTokens has input/output tokens only) — a prorated estimate
+		// would read as authoritative to spreadsheet consumers despite being inaccurate whenever
+		// the model mix varies day to day. Needs a backend field before this can be added for real.
 		const headers = ["Date", "Input Tokens", "Output Tokens", "Total Tokens"];
 		const csvRows = [
 			headers.join(","),
@@ -257,8 +261,8 @@ function AdvancedView() {
 								mode="range"
 								defaultMonth={new Date()}
 								selected={{
-									from: startDate ? new Date(startDate) : undefined,
-									to: endDate ? new Date(endDate) : undefined,
+									from: startDate ? dayjs(startDate).toDate() : undefined,
+									to: endDate ? dayjs(endDate).toDate() : undefined,
 								}}
 								onSelect={(range) => {
 									if (range?.from) {

--- a/src/routes/usage.tsx
+++ b/src/routes/usage.tsx
@@ -244,6 +244,7 @@ function AdvancedView() {
 					<PopoverAnchor>
 						<div ref={rangeToggleRef}>
 							<ToggleGroup
+								className="flex-wrap"
 								value={timeRange}
 								onValueChange={(value) => {
 									if (value === "custom") {

--- a/src/routes/usage.tsx
+++ b/src/routes/usage.tsx
@@ -11,12 +11,13 @@ import {
 	Zap,
 } from "lucide-react";
 import { useRequireAuth } from "@/hooks/use-auth";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { useUsageStats } from "@/hooks/data/use-stats";
 import { useSubscription, AllowanceBar } from "@libertai/auth";
 import { Calendar } from "@libertai/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@libertai/ui/popover";
+import { Popover, PopoverAnchor, PopoverContent } from "@libertai/ui/popover";
+import { ToggleGroup } from "@libertai/ui/toggle-group";
 import { Skeleton } from "@libertai/ui/skeleton";
 import { formatCompactNumber } from "@/lib/utils";
 import dayjs from "dayjs";
@@ -76,7 +77,7 @@ function OverviewView() {
 					icon={<Zap className="h-5 w-5 text-primary" />}
 					title={
 						<>
-							Current plan: <span className="capitalize text-primary">{currentTier}</span>
+							Current plan: <span className="capitalize text-primary-text">{currentTier}</span>
 							{subscription?.cancel_at_period_end && (
 								<span className="text-sm font-normal text-muted-foreground ml-2">(cancels at period end)</span>
 							)}
@@ -142,6 +143,11 @@ function AdvancedView() {
 	const [timeRange, setTimeRange] = useState<"7d" | "30d" | "custom">("7d");
 	const [startDate, setStartDate] = useState<string>(formatDate(dayjs().subtract(7, "day").toDate()));
 	const [endDate, setEndDate] = useState<string>(formatDate(new Date()));
+	const [isCustomRangeOpen, setIsCustomRangeOpen] = useState(false);
+	// PopoverAnchor isn't a real PopoverTrigger, so Radix's dismissable layer doesn't know to
+	// exempt clicks on it — without this ref + onInteractOutside below, a pointerdown on the
+	// toggle closes the popover a beat before our own onValueChange re-opens it.
+	const rangeToggleRef = useRef<HTMLDivElement>(null);
 
 	const {
 		dailyChartData,
@@ -234,49 +240,70 @@ function AdvancedView() {
 	return (
 		<div className="flex flex-col space-y-8">
 			<div className="flex justify-end">
-				<div className="inline-flex flex-wrap gap-1 rounded-lg border border-border p-1 bg-card">
-					<Button variant={timeRange === "7d" ? "default" : "ghost"} size="sm" onClick={() => setTimeRange("7d")}>
-						7 days
-					</Button>
-					<Button variant={timeRange === "30d" ? "default" : "ghost"} size="sm" onClick={() => setTimeRange("30d")}>
-						30 days
-					</Button>
-					<Popover>
-						<PopoverTrigger asChild>
-							<Button
-								variant={timeRange === "custom" ? "default" : "ghost"}
-								size="sm"
-								className="w-auto justify-start text-left font-normal"
-							>
-								<CalendarIcon className="mr-2 h-4 w-4" />
-								{timeRange === "custom"
-									? startDate === endDate
-										? startDate
-										: `${startDate} - ${endDate}`
-									: "Custom range"}
-							</Button>
-						</PopoverTrigger>
-						<PopoverContent className="w-auto p-0" align="start">
-							<Calendar
-								mode="range"
-								defaultMonth={new Date()}
-								selected={{
-									from: startDate ? dayjs(startDate).toDate() : undefined,
-									to: endDate ? dayjs(endDate).toDate() : undefined,
-								}}
-								onSelect={(range) => {
-									if (range?.from) {
+				<Popover open={isCustomRangeOpen} onOpenChange={setIsCustomRangeOpen}>
+					<PopoverAnchor>
+						<div ref={rangeToggleRef}>
+							<ToggleGroup
+								value={timeRange}
+								onValueChange={(value) => {
+									if (value === "custom") {
 										setTimeRange("custom");
-										setStartDate(formatDate(range.from));
-										setEndDate(formatDate(range.to || range.from));
+										setIsCustomRangeOpen((open) => !open);
+										return;
 									}
+									setTimeRange(value as "7d" | "30d");
+									setIsCustomRangeOpen(false);
 								}}
-								initialFocus
-								disabled={(date) => date > new Date()}
+								options={[
+									{ value: "7d", label: "7 days" },
+									{ value: "30d", label: "30 days" },
+									{
+										value: "custom",
+										label: (
+											<span className="flex items-center">
+												<CalendarIcon className="mr-2 h-4 w-4" />
+												{timeRange === "custom"
+													? startDate === endDate
+														? startDate
+														: `${startDate} - ${endDate}`
+													: "Custom range"}
+											</span>
+										),
+									},
+								]}
 							/>
-						</PopoverContent>
-					</Popover>
-				</div>
+						</div>
+					</PopoverAnchor>
+					<PopoverContent
+						className="w-auto p-0"
+						align="start"
+						onInteractOutside={(e) => {
+							// Let clicks on the toggle go through onValueChange instead of the layer's
+							// default outside-dismiss, so re-clicking "custom" can close the popover.
+							if (rangeToggleRef.current?.contains(e.target as Node)) {
+								e.preventDefault();
+							}
+						}}
+					>
+						<Calendar
+							mode="range"
+							defaultMonth={new Date()}
+							selected={{
+								from: startDate ? dayjs(startDate).toDate() : undefined,
+								to: endDate ? dayjs(endDate).toDate() : undefined,
+							}}
+							onSelect={(range) => {
+								if (range?.from) {
+									setTimeRange("custom");
+									setStartDate(formatDate(range.from));
+									setEndDate(formatDate(range.to || range.from));
+								}
+							}}
+							initialFocus
+							disabled={(date) => date > new Date()}
+						/>
+					</PopoverContent>
+				</Popover>
 			</div>
 
 			{isError ? (
@@ -446,14 +473,14 @@ function Usage() {
 					description="Monitor your API usage and costs"
 					action={
 						SHOW_PLAN_OVERVIEW && (
-							<div className="inline-flex rounded-lg border border-border p-1 bg-card">
-								<Button variant={view === "overview" ? "default" : "ghost"} size="sm" onClick={() => setView("overview")}>
-									Overview
-								</Button>
-								<Button variant={view === "advanced" ? "default" : "ghost"} size="sm" onClick={() => setView("advanced")}>
-									Advanced
-								</Button>
-							</div>
+							<ToggleGroup
+								value={view}
+								onValueChange={(value) => setView(value as "overview" | "advanced")}
+								options={[
+									{ value: "overview", label: "Overview" },
+									{ value: "advanced", label: "Advanced" },
+								]}
+							/>
 						)
 					}
 				/>

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,12 +7,3 @@
 @plugin "tailwindcss-animate";
 
 @custom-variant dark (&:is(.dark *));
-
-/* The shared theme sets --input to the card surface color, so input/select/switch/outline
-   borders and fills vanish against cards. Override with a surface-independent border token. */
-:root {
-	--input: oklch(0.78 0 0);
-}
-.dark {
-	--input: oklch(1 0 0 / 18%);
-}


### PR DESCRIPTION
Applies the 4-lens design review (tokens, visual, controls, UX). Shared main already pushed (`d63a25c`).

## Dark mode (the headline)
- One near-black surface family `#171825` for cards/inputs/menus (the billing-card shade) — kills the grey select pills and the blue-vs-neutral hue split; `secondary` steps up to `#1F2030`, borders/shadows separate equal surfaces
- Field/control borders moved to `border-border` so inputs/selects/textareas/switches keep visible bounds on cards (both themes)
- New `text-primary-text` token (`#8B7BFF` dark) for AA body text/links; buttons keep brand purple

## Consistency
- Labels are `text-foreground` (no longer identical to table headers); light `muted-foreground` darkened to pass AA (123 usages)
- 3px focus rings everywhere; shared `ToggleGroup` primitive replaces 3 hand-rolled pill toggles
- Chart tokens rebuilt brand-anchored (all ≥3:1 on card, verified computationally)

## Bugs fixed
- Create/Edit key **double-submit** (form was gated on the list query, not the mutation)
- Custom-range calendar **off-by-one** in negative-UTC timezones
- Landing terminal card was **invisible in dark mode** (hardcoded zinc ≈ page bg); hero now vertically centered
- Mobile drawer native-blue focus ring (Link/asChild composition); Billing sidebar item now highlights on /plans + /top-up and stays clickable
- ConfirmDialog "undefined" flash; raw FastAPI details no longer reach toasts; stat cards show — instead of silent 0 on error

## Click-test before merge (authed pages not live-driven; both themes)
- [ ] Images + API keys: selects/inputs/textarea have visible bounds on cards; Switch track visible in edit dialog
- [ ] Create key: double-click produces ONE key; delete confirm shows right name with no flash
- [ ] Usage custom range: pick July 1 → chip shows July 1; re-click "custom" closes the calendar; 7d/30d while open closes it
- [ ] /plans and /top-up: Billing highlighted AND navigates back to /billing
- [ ] Landing dark: terminal card reads as a lifted surface; hero centered
- [ ] Offline: friendly toasts, em-dashes on stat cards

Counterpart chat PR consumes the same shared SHA.