### PR TITLE
Connected devices on the API keys tab

### DIFF
--- a/src/components/CliDevices.tsx
+++ b/src/components/CliDevices.tsx
@@ -147,13 +147,14 @@ function DeviceRow({
 }
 
 export function CliDevices() {
-	const { devices, isLoading, isError, refetch, disconnectDevice, disconnectStatus } = useCliDevices();
+	const { devices, isLoading, isError, refetch, disconnectDevice } = useCliDevices();
 	const [pendingDisconnect, setPendingDisconnect] = useState<CliApiKey | null>(null);
 	// Survives the dialog's close animation so the description doesn't flash while it fades.
 	const [pendingName, setPendingName] = useState<string | null>(null);
-	// ConfirmDialog clears pendingDisconnect the instant onConfirm fires, so the row that's
-	// mid-disconnect needs its own id to stay disabled until the mutation settles.
-	const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
+	// ConfirmDialog clears pendingDisconnect the instant onConfirm fires, so an in-flight row
+	// needs its own id — and a set, not a scalar, since the mutation allows concurrent calls
+	// (disconnect A, then B before A settles) and each row's disabled state is independent.
+	const [disconnectingIds, setDisconnectingIds] = useState<ReadonlySet<string>>(new Set());
 
 	const sorted = useMemo(() => sortDevices(devices), [devices]);
 
@@ -190,7 +191,7 @@ export function CliDevices() {
 							<DeviceRow
 								key={device.id}
 								device={device}
-								disconnecting={disconnectingId === device.id && disconnectStatus === "pending"}
+								disconnecting={disconnectingIds.has(device.id)}
 								onDisconnect={() => {
 									setPendingDisconnect(device);
 									setPendingName(parseDeviceName(device.name).name);
@@ -221,12 +222,18 @@ export function CliDevices() {
 				onConfirm={() => {
 					if (!pendingDisconnect) return;
 					const id = pendingDisconnect.id;
-					setDisconnectingId(id);
+					setDisconnectingIds((current) => new Set(current).add(id));
 					// mutateAsync rejects even with onError set (react-query v5); the hook's
 					// onError already toasts, so swallow the rejection here.
 					void disconnectDevice(id)
 						.catch(() => {})
-						.finally(() => setDisconnectingId((current) => (current === id ? null : current)));
+						.finally(() =>
+							setDisconnectingIds((current) => {
+								const next = new Set(current);
+								next.delete(id);
+								return next;
+							}),
+						);
 				}}
 			/>
 		</Card>

--- a/src/components/CliDevices.tsx
+++ b/src/components/CliDevices.tsx
@@ -1,0 +1,205 @@
+import { useMemo, useState } from "react";
+import { Terminal } from "lucide-react";
+import { Button } from "@libertai/ui/button";
+import { Card, CardHeader } from "@libertai/ui/card";
+import { ConfirmDialog } from "@libertai/ui/confirm-dialog";
+import { ErrorCard } from "@libertai/ui/error-card";
+import { Skeleton } from "@libertai/ui/skeleton";
+import { ToggleGroup } from "@libertai/ui/toggle-group";
+import { CliApiKey } from "@libertai/inference-sdk";
+import { CodeBlock } from "@/components/CodeBlock";
+import { useCliDevices } from "@/hooks/data/use-cli-keys";
+import { parseDeviceName, sortDevices } from "@/lib/cli-devices";
+import { daysUntil, fromNow, shortDate } from "@/lib/time";
+
+const CODE_URL = "https://code.libertai.io";
+const WINDOWS_RELEASES_URL = "https://github.com/Libertai/libertai-cli/releases/latest";
+const LOGIN_COMMAND = "libertai login";
+// Devices this close to expiry get a renewal nudge; past it the key vanishes from the list.
+const EXPIRY_WARNING_DAYS = 30;
+
+const INSTALL_METHODS = [
+	{
+		value: "unix",
+		label: "Linux / macOS",
+		command: "curl -fsSL https://raw.githubusercontent.com/Libertai/libertai-cli/master/packaging/install.sh | sh",
+	},
+	{ value: "apt", label: "Debian / Ubuntu", command: "curl -fsSL https://apt.libertai.io/install.sh | sudo bash" },
+	{ value: "brew", label: "Homebrew", command: "brew install Libertai/tap/libertai" },
+	{
+		value: "cargo",
+		label: "Rust",
+		command: "cargo install --git https://github.com/Libertai/libertai-cli --branch master --locked",
+	},
+];
+
+// None of the install commands run on native Windows, and the .exe build is surfaced
+// nowhere else. macOS and Linux both want the first tab, so they need no detection.
+function isWindows(): boolean {
+	const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
+	return /win/i.test(nav.userAgentData?.platform ?? nav.platform ?? "");
+}
+
+function SeeMoreLink() {
+	return (
+		<a href={CODE_URL} className="text-primary-text underline" target="_blank" rel="noopener noreferrer">
+			See more
+		</a>
+	);
+}
+
+function InstallBlock() {
+	const [method, setMethod] = useState(INSTALL_METHODS[0].value);
+	const [windows] = useState(isWindows);
+	const selected = INSTALL_METHODS.find((m) => m.value === method) ?? INSTALL_METHODS[0];
+
+	return (
+		<div className="space-y-3">
+			{windows && (
+				<p className="text-sm text-muted-foreground">
+					No native Windows install yet — use WSL with the Linux / macOS command, or grab the{" "}
+					<a
+						href={WINDOWS_RELEASES_URL}
+						className="text-primary-text underline"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						.exe from the latest release
+					</a>
+					.
+				</p>
+			)}
+			<ToggleGroup
+				className="flex-wrap"
+				value={method}
+				onValueChange={setMethod}
+				options={INSTALL_METHODS.map((m) => ({ value: m.value, label: m.label }))}
+			/>
+			<CodeBlock value={selected.command} copyLabel={`Copy ${selected.label} install command`} />
+			<p className="text-sm text-muted-foreground">Then connect this machine:</p>
+			<CodeBlock value={LOGIN_COMMAND} copyLabel="Copy login command" />
+		</div>
+	);
+}
+
+function EmptyState() {
+	return (
+		<div className="space-y-4 px-6 py-4">
+			<h3 className="text-lg font-semibold">Your agent. Your inference. Your machine.</h3>
+			<p className="text-sm text-muted-foreground">
+				Keep the coding agent you already use — <strong className="text-foreground">Claude Code, OpenCode</strong> —
+				and run it on <strong className="text-foreground">open-weights models you control</strong>. Private by
+				default, no vendor lock-in, no wallet. We don't replace your agent; we just swap the backend. One command.
+			</p>
+			<InstallBlock />
+			<p className="text-sm text-muted-foreground">
+				<SeeMoreLink />
+			</p>
+		</div>
+	);
+}
+
+function DeviceRow({ device, onDisconnect }: { device: CliApiKey; onDisconnect: () => void }) {
+	const { name, installId } = parseDeviceName(device.name);
+	const lastUsed = fromNow(device.last_used_at);
+	const connected = shortDate(device.created_at);
+	const expiresIn = daysUntil(device.expires_at);
+
+	return (
+		<li className="flex flex-wrap items-start justify-between gap-3 px-6 py-4">
+			<div className="flex min-w-0 items-start gap-3">
+				<Terminal className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden />
+				<div className="min-w-0 space-y-1">
+					<div className="flex flex-wrap items-baseline gap-2">
+						<span className="font-medium break-all">{name}</span>
+						{installId && <span className="font-mono text-xs text-muted-foreground">{installId}</span>}
+					</div>
+					<p className="text-sm text-muted-foreground">
+						{lastUsed ? `Last used ${lastUsed} · Connected ${connected}` : `Connected ${connected} · No requests yet`}
+					</p>
+					{expiresIn !== null && expiresIn <= EXPIRY_WARNING_DAYS && (
+						<p className="text-sm text-amber-500">
+							Expires in {expiresIn} {expiresIn === 1 ? "day" : "days"} — run {LOGIN_COMMAND} on that machine to
+							renew
+						</p>
+					)}
+				</div>
+			</div>
+			<Button variant="outline" size="sm" onClick={onDisconnect} aria-label={`Disconnect ${name}`}>
+				Disconnect
+			</Button>
+		</li>
+	);
+}
+
+export function CliDevices() {
+	const { devices, isLoading, isError, refetch, disconnectDevice } = useCliDevices();
+	const [pendingDisconnect, setPendingDisconnect] = useState<CliApiKey | null>(null);
+	// Survives the dialog's close animation so the description doesn't flash while it fades.
+	const [pendingName, setPendingName] = useState<string | null>(null);
+
+	const sorted = useMemo(() => sortDevices(devices), [devices]);
+
+	return (
+		<Card className="p-0 overflow-hidden">
+			{/* Card hardcodes p-6, so every block inside a p-0 card carries its own padding. */}
+			<div className="px-6 pt-6">
+				<CardHeader
+					title="Connected devices"
+					icon={<Terminal className="h-5 w-5 text-primary" />}
+					className="mb-2"
+				/>
+				<p className="text-sm text-muted-foreground">Machines signed in with the LibertAI CLI or Desktop app.</p>
+			</div>
+
+			{isLoading ? (
+				<div className="space-y-2 px-6 py-4">
+					<Skeleton className="h-16 w-full" />
+					<Skeleton className="h-16 w-full" />
+				</div>
+			) : isError && devices.length === 0 ? (
+				// react-query keeps data on a failed background refetch, so an unguarded
+				// isError would replace a working list with an error card.
+				<ErrorCard plain message="Couldn't load your connected devices." onRetry={refetch} />
+			) : sorted.length === 0 ? (
+				<EmptyState />
+			) : (
+				<>
+					<ul className="divide-y divide-border border-t border-border">
+						{sorted.map((device) => (
+							<DeviceRow
+								key={device.id}
+								device={device}
+								onDisconnect={() => {
+									setPendingDisconnect(device);
+									setPendingName(parseDeviceName(device.name).name);
+								}}
+							/>
+						))}
+					</ul>
+					<div className="flex flex-wrap gap-3 border-t border-border px-6 py-4 text-sm text-muted-foreground">
+						<span>
+							Install on another machine →{" "}
+							<a href={CODE_URL} className="text-primary-text underline" target="_blank" rel="noopener noreferrer">
+								code.libertai.io
+							</a>
+						</span>
+					</div>
+					<div className="px-6 pb-6">
+						<CodeBlock value={LOGIN_COMMAND} copyLabel="Copy login command" />
+					</div>
+				</>
+			)}
+
+			<ConfirmDialog
+				open={!!pendingDisconnect}
+				onOpenChange={(open) => !open && setPendingDisconnect(null)}
+				title="Disconnect device"
+				description={`${pendingName} will stop making requests. Sign in again with libertai login on that machine to reconnect.`}
+				confirmLabel="Disconnect"
+				destructive
+				onConfirm={() => pendingDisconnect && disconnectDevice(pendingDisconnect.id)}
+			/>
+		</Card>
+	);
+}

--- a/src/components/CliDevices.tsx
+++ b/src/components/CliDevices.tsx
@@ -99,7 +99,15 @@ function EmptyState() {
 	);
 }
 
-function DeviceRow({ device, onDisconnect }: { device: CliApiKey; onDisconnect: () => void }) {
+function DeviceRow({
+	device,
+	onDisconnect,
+	disconnecting,
+}: {
+	device: CliApiKey;
+	onDisconnect: () => void;
+	disconnecting: boolean;
+}) {
 	const { name, installId } = parseDeviceName(device.name);
 	const lastUsed = fromNow(device.last_used_at);
 	const connected = shortDate(device.created_at);
@@ -125,25 +133,34 @@ function DeviceRow({ device, onDisconnect }: { device: CliApiKey; onDisconnect: 
 					)}
 				</div>
 			</div>
-			<Button variant="outline" size="sm" onClick={onDisconnect} aria-label={`Disconnect ${name}`}>
-				Disconnect
+			<Button
+				variant="outline"
+				size="sm"
+				onClick={onDisconnect}
+				disabled={disconnecting}
+				aria-label={`Disconnect ${name}`}
+			>
+				{disconnecting ? "Disconnecting…" : "Disconnect"}
 			</Button>
 		</li>
 	);
 }
 
 export function CliDevices() {
-	const { devices, isLoading, isError, refetch, disconnectDevice } = useCliDevices();
+	const { devices, isLoading, isError, refetch, disconnectDevice, disconnectStatus } = useCliDevices();
 	const [pendingDisconnect, setPendingDisconnect] = useState<CliApiKey | null>(null);
 	// Survives the dialog's close animation so the description doesn't flash while it fades.
 	const [pendingName, setPendingName] = useState<string | null>(null);
+	// ConfirmDialog clears pendingDisconnect the instant onConfirm fires, so the row that's
+	// mid-disconnect needs its own id to stay disabled until the mutation settles.
+	const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
 
 	const sorted = useMemo(() => sortDevices(devices), [devices]);
 
 	return (
 		<Card className="p-0 overflow-hidden">
 			{/* Card hardcodes p-6, so every block inside a p-0 card carries its own padding. */}
-			<div className="px-6 pt-6">
+			<div className="px-6 pt-6 pb-4">
 				<CardHeader
 					title="Connected devices"
 					icon={<Terminal className="h-5 w-5 text-primary" />}
@@ -173,6 +190,7 @@ export function CliDevices() {
 							<DeviceRow
 								key={device.id}
 								device={device}
+								disconnecting={disconnectingId === device.id && disconnectStatus === "pending"}
 								onDisconnect={() => {
 									setPendingDisconnect(device);
 									setPendingName(parseDeviceName(device.name).name);
@@ -180,15 +198,14 @@ export function CliDevices() {
 							/>
 						))}
 					</ul>
-					<div className="flex flex-wrap gap-3 border-t border-border px-6 py-4 text-sm text-muted-foreground">
-						<span>
-							Install on another machine →{" "}
-							<a href={CODE_URL} className="text-primary-text underline" target="_blank" rel="noopener noreferrer">
-								code.libertai.io
-							</a>
-						</span>
+					<div className="border-t border-border px-6 py-4 text-sm text-muted-foreground">
+						Install on another machine →{" "}
+						<a href={CODE_URL} className="text-primary-text underline" target="_blank" rel="noopener noreferrer">
+							code.libertai.io
+						</a>
 					</div>
-					<div className="px-6 pb-6">
+					<div className="space-y-2 px-6 pb-6">
+						<p className="text-sm text-muted-foreground">Already installed? Renew or connect this machine:</p>
 						<CodeBlock value={LOGIN_COMMAND} copyLabel="Copy login command" />
 					</div>
 				</>
@@ -201,7 +218,16 @@ export function CliDevices() {
 				description={`${pendingName} will stop making requests. Sign in again with libertai login on that machine to reconnect.`}
 				confirmLabel="Disconnect"
 				destructive
-				onConfirm={() => pendingDisconnect && disconnectDevice(pendingDisconnect.id)}
+				onConfirm={() => {
+					if (!pendingDisconnect) return;
+					const id = pendingDisconnect.id;
+					setDisconnectingId(id);
+					// mutateAsync rejects even with onError set (react-query v5); the hook's
+					// onError already toasts, so swallow the rejection here.
+					void disconnectDevice(id)
+						.catch(() => {})
+						.finally(() => setDisconnectingId((current) => (current === id ? null : current)));
+				}}
 			/>
 		</Card>
 	);

--- a/src/components/CliDevices.tsx
+++ b/src/components/CliDevices.tsx
@@ -160,7 +160,10 @@ export function CliDevices() {
 			) : isError && devices.length === 0 ? (
 				// react-query keeps data on a failed background refetch, so an unguarded
 				// isError would replace a working list with an error card.
-				<ErrorCard plain message="Couldn't load your connected devices." onRetry={refetch} />
+				// ErrorCard's plain mode has no horizontal padding of its own — supply it here.
+				<div className="px-6">
+					<ErrorCard plain message="Couldn't load your connected devices." onRetry={refetch} />
+				</div>
 			) : sorted.length === 0 ? (
 				<EmptyState />
 			) : (

--- a/src/components/CliDevices.tsx
+++ b/src/components/CliDevices.tsx
@@ -57,7 +57,7 @@ function InstallBlock() {
 		<div className="space-y-3">
 			{windows && (
 				<p className="text-sm text-muted-foreground">
-					No native Windows install yet — use WSL with the Linux / macOS command, or grab the{" "}
+					No native Windows install yet. Use WSL with the Linux / macOS command, or grab the{" "}
 					<a
 						href={WINDOWS_RELEASES_URL}
 						className="text-primary-text underline"
@@ -87,9 +87,10 @@ function EmptyState() {
 		<div className="space-y-4 px-6 py-4">
 			<h3 className="text-lg font-semibold">Your agent. Your inference. Your machine.</h3>
 			<p className="text-sm text-muted-foreground">
-				Keep the coding agent you already use — <strong className="text-foreground">Claude Code, OpenCode</strong> —
-				and run it on <strong className="text-foreground">open-weights models you control</strong>. Private by
-				default, no vendor lock-in, no wallet. We don't replace your agent; we just swap the backend. One command.
+				Keep the coding agent you already use, like{" "}
+				<strong className="text-foreground">Claude Code, OpenCode</strong>, and run it on{" "}
+				<strong className="text-foreground">open-weights models you control</strong>. Private by default, no vendor
+				lock-in, no wallet. We don't replace your agent; we just swap the backend. One command.
 			</p>
 			<InstallBlock />
 			<p className="text-sm text-muted-foreground">
@@ -114,7 +115,7 @@ function DeviceRow({
 	const expiresIn = daysUntil(device.expires_at);
 
 	return (
-		<li className="flex flex-wrap items-start justify-between gap-3 px-6 py-4">
+		<li className="flex flex-wrap items-start gap-3 px-6 py-4">
 			<div className="flex min-w-0 items-start gap-3">
 				<Terminal className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden />
 				<div className="min-w-0 space-y-1">
@@ -127,8 +128,8 @@ function DeviceRow({
 					</p>
 					{expiresIn !== null && expiresIn <= EXPIRY_WARNING_DAYS && (
 						<p className="text-sm text-amber-500">
-							Expires in {expiresIn} {expiresIn === 1 ? "day" : "days"} — run {LOGIN_COMMAND} on that machine to
-							renew
+							Expires in {expiresIn} {expiresIn === 1 ? "day" : "days"}. Run {LOGIN_COMMAND} on that machine to
+							renew.
 						</p>
 					)}
 				</div>
@@ -139,6 +140,7 @@ function DeviceRow({
 				onClick={onDisconnect}
 				disabled={disconnecting}
 				aria-label={`Disconnect ${name}`}
+				className="ml-auto"
 			>
 				{disconnecting ? "Disconnecting…" : "Disconnect"}
 			</Button>
@@ -152,7 +154,7 @@ export function CliDevices() {
 	// Survives the dialog's close animation so the description doesn't flash while it fades.
 	const [pendingName, setPendingName] = useState<string | null>(null);
 	// ConfirmDialog clears pendingDisconnect the instant onConfirm fires, so an in-flight row
-	// needs its own id — and a set, not a scalar, since the mutation allows concurrent calls
+	// needs its own id, and a set, not a scalar, since the mutation allows concurrent calls
 	// (disconnect A, then B before A settles) and each row's disabled state is independent.
 	const [disconnectingIds, setDisconnectingIds] = useState<ReadonlySet<string>>(new Set());
 
@@ -178,7 +180,7 @@ export function CliDevices() {
 			) : isError && devices.length === 0 ? (
 				// react-query keeps data on a failed background refetch, so an unguarded
 				// isError would replace a working list with an error card.
-				// ErrorCard's plain mode has no horizontal padding of its own — supply it here.
+				// ErrorCard's plain mode has no horizontal padding of its own, supply it here.
 				<div className="px-6">
 					<ErrorCard plain message="Couldn't load your connected devices." onRetry={refetch} />
 				</div>

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,22 @@
+import { CopyButton } from "@libertai/ui/copy-button";
+import { cn } from "@/lib/utils";
+
+export function CodeBlock({
+	value,
+	copyLabel,
+	className,
+}: {
+	value: string;
+	copyLabel?: string;
+	className?: string;
+}) {
+	return (
+		<div className={cn("relative rounded-md border border-border/50 bg-secondary/50 p-4", className)}>
+			{/* pr-12 keeps the copy button off the first line — the install one-liner is 99 chars. */}
+			<pre className="overflow-x-auto pr-12 font-mono text-sm whitespace-pre-wrap">{value}</pre>
+			<div className="absolute top-2 right-2">
+				<CopyButton value={value} label={copyLabel} />
+			</div>
+		</div>
+	);
+}

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -12,7 +12,7 @@ export function CodeBlock({
 }) {
 	return (
 		<div className={cn("relative rounded-md border border-border/50 bg-secondary/50 p-4", className)}>
-			{/* pr-12 keeps the copy button off the first line — the install one-liner is 99 chars. */}
+			{/* pr-12 keeps the copy button off the first line, the install one-liner is 99 chars. */}
 			<pre className="overflow-x-auto pr-12 font-mono text-sm whitespace-pre-wrap">{value}</pre>
 			<div className="absolute top-2 right-2">
 				<CopyButton value={value} label={copyLabel} />

--- a/src/hooks/data/use-cli-keys.ts
+++ b/src/hooks/data/use-cli-keys.ts
@@ -52,6 +52,5 @@ export function useCliDevices() {
 		isError: query.isError,
 		refetch: query.refetch,
 		disconnectDevice: disconnectMutation.mutateAsync,
-		disconnectStatus: disconnectMutation.status,
 	};
 }

--- a/src/hooks/data/use-cli-keys.ts
+++ b/src/hooks/data/use-cli-keys.ts
@@ -1,0 +1,57 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { deleteApiKeyApiKeysKeyIdDelete, getCliApiKeysApiKeysCliGet } from "@libertai/inference-sdk";
+import { useAccountStore } from "@libertai/auth";
+
+export function useCliDevices() {
+	const queryClient = useQueryClient();
+	const isAuthenticated = useAccountStore((state) => state.isAuthenticated);
+
+	const query = useQuery({
+		queryKey: ["cliDevices"],
+		queryFn: async () => {
+			const response = await getCliApiKeysApiKeysCliGet();
+
+			if (response.error) {
+				throw new Error("Couldn't load your connected devices.");
+			}
+
+			return response.data;
+		},
+		enabled: isAuthenticated,
+		// The flow is: run `libertai login` in a terminal, tab back here. The global
+		// 5-minute staleTime would leave the list wrong for the whole of that window.
+		staleTime: 30_000,
+		refetchOnWindowFocus: true,
+	});
+
+	const disconnectMutation = useMutation({
+		mutationFn: async (keyId: string) => {
+			const response = await deleteApiKeyApiKeysKeyIdDelete({ path: { key_id: keyId } });
+
+			if (response.error) {
+				throw new Error("Something went wrong. Try again.");
+			}
+
+			return true;
+		},
+		onSuccess: async () => {
+			toast.success("Device disconnected");
+			await queryClient.invalidateQueries({ queryKey: ["cliDevices"] });
+		},
+		onError: (error) => {
+			toast.error("Failed to disconnect device", {
+				description: error instanceof Error ? error.message : "An unknown error occurred",
+			});
+		},
+	});
+
+	return {
+		devices: query.data ?? [],
+		isLoading: query.isLoading,
+		isError: query.isError,
+		refetch: query.refetch,
+		disconnectDevice: disconnectMutation.mutateAsync,
+		disconnectStatus: disconnectMutation.status,
+	};
+}

--- a/src/lib/cli-devices.ts
+++ b/src/lib/cli-devices.ts
@@ -1,0 +1,37 @@
+import { ts } from "./time";
+
+const CLI_KEY_PREFIX = "libertai-cli@";
+// The CLI appends hex::encode of 4 random bytes — always lowercase, always 8 chars. The
+// pattern is case-sensitive so an uppercase hostname segment like DEADBEEF is not eaten.
+const INSTALL_ID = /^(.*)-([0-9a-f]{8})$/;
+
+export type DeviceLabel = { name: string; installId: string | null };
+
+export function parseDeviceName(rawName: string): DeviceLabel {
+	if (!rawName.startsWith(CLI_KEY_PREFIX)) {
+		return { name: "Unknown device", installId: null };
+	}
+	const host = rawName.slice(CLI_KEY_PREFIX.length);
+	if (host === "") {
+		return { name: "Unknown device", installId: null };
+	}
+	const match = INSTALL_ID.exec(host);
+	return match ? { name: match[1], installId: match[2] } : { name: host, installId: null };
+}
+
+type Sortable = { last_used_at?: string | null; created_at: string };
+
+// Most recently used first, never-used last, then newest connection first. Copies the
+// array: sorting the query result in place would mutate the react-query cache.
+export function sortDevices<T extends Sortable>(devices: T[]): T[] {
+	return [...devices].sort((a, b) => {
+		const aUsed = ts(a.last_used_at);
+		const bUsed = ts(b.last_used_at);
+		if (aUsed !== bUsed) {
+			if (aUsed === null) return 1;
+			if (bUsed === null) return -1;
+			return bUsed - aUsed;
+		}
+		return (ts(b.created_at) ?? 0) - (ts(a.created_at) ?? 0);
+	});
+}

--- a/src/lib/cli-devices.ts
+++ b/src/lib/cli-devices.ts
@@ -1,7 +1,7 @@
 import { ts } from "./time";
 
 const CLI_KEY_PREFIX = "libertai-cli@";
-// The CLI appends hex::encode of 4 random bytes — always lowercase, always 8 chars. The
+// The CLI appends hex::encode of 4 random bytes, always lowercase, always 8 chars. The
 // pattern is case-sensitive so an uppercase hostname segment like DEADBEEF is not eaten.
 const INSTALL_ID = /^(.*)-([0-9a-f]{8})$/;
 

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,25 @@
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+dayjs.extend(relativeTime);
+
+type Timestamp = string | null | undefined;
+
+// Backend timestamps are naive TIMESTAMP columns holding UTC, serialized without an
+// offset — a bare dayjs() would read them as browser-local. Every consumer must go
+// through these helpers. Scope: new code; existing date-only formats are unaffected.
+const at = (value: string) => dayjs.utc(value).local();
+
+export const ts = (value: Timestamp) => (value ? at(value).valueOf() : null);
+
+export const fromNow = (value: Timestamp) => (value ? at(value).fromNow() : null);
+
+// Whole days, rounded up, floored at 0. Not dayjs's toNow(): it renders everything from
+// roughly 25 to 46 days as "a month".
+export const daysUntil = (value: Timestamp) =>
+	value ? Math.max(0, Math.ceil((at(value).valueOf() - Date.now()) / 86_400_000)) : null;
+
+export const shortDate = (value: Timestamp) =>
+	value ? at(value).format(at(value).isSame(dayjs(), "year") ? "MMM D" : "MMM D, YYYY") : null;

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -8,7 +8,7 @@ dayjs.extend(relativeTime);
 type Timestamp = string | null | undefined;
 
 // Backend timestamps are naive TIMESTAMP columns holding UTC, serialized without an
-// offset — a bare dayjs() would read them as browser-local. Every consumer must go
+// offset, a bare dayjs() would read them as browser-local. Every consumer must go
 // through these helpers. Scope: new code; existing date-only formats are unaffected.
 const at = (value: string) => dayjs.utc(value).local();
 

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -21,5 +21,10 @@ export const fromNow = (value: Timestamp) => (value ? at(value).fromNow() : null
 export const daysUntil = (value: Timestamp) =>
 	value ? Math.max(0, Math.ceil((at(value).valueOf() - Date.now()) / 86_400_000)) : null;
 
-export const shortDate = (value: Timestamp) =>
-	value ? at(value).format(at(value).isSame(dayjs(), "year") ? "MMM D" : "MMM D, YYYY") : null;
+// The year is only shown outside the current one: device keys live 90 days, so
+// created_at legitimately crosses a year boundary.
+export const shortDate = (value: Timestamp) => {
+	if (!value) return null;
+	const date = at(value);
+	return date.format(date.isSame(dayjs(), "year") ? "MMM D" : "MMM D, YYYY");
+};

--- a/src/routes/api-keys.tsx
+++ b/src/routes/api-keys.tsx
@@ -16,6 +16,7 @@ import { useUsageStats } from "@/hooks/data/use-stats";
 import { useAlephModels } from "@/hooks/data/use-models";
 import { toast } from "sonner";
 import { ApiKeyForm } from "@/components/ApiKeyForm";
+import { CliDevices } from "@/components/CliDevices";
 import { Skeleton } from "@libertai/ui/skeleton";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@libertai/ui/select";
 import { Card, CardHeader } from "@libertai/ui/card";
@@ -106,60 +107,6 @@ const response = await client.chat.completions.create({
 console.log(response.choices[0].message.content);`;
 	}
 };
-
-type ToolIntegration = {
-	name: string;
-	description: string;
-	snippet: (model: string) => string;
-	language: string;
-};
-
-const TOOL_INTEGRATIONS: ToolIntegration[] = [
-	{
-		name: "Claude Code",
-		description: "Point the Anthropic-compatible endpoint at LibertAI via environment variables.",
-		language: "bash",
-		snippet: (model) => `export ANTHROPIC_BASE_URL="https://api.libertai.io"
-export ANTHROPIC_AUTH_TOKEN="YOUR_API_KEY"
-export ANTHROPIC_DEFAULT_OPUS_MODEL="${model}"
-export ANTHROPIC_DEFAULT_SONNET_MODEL="${model}"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="${model}"
-export CLAUDE_CODE_ATTRIBUTION_HEADER=0
-export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
-
-claude`,
-	},
-	{
-		name: "Cursor",
-		description:
-			"In Settings → Models, enable “Override OpenAI Base URL”, paste the URL and your key, then add the model name below.",
-		language: "text",
-		snippet: (model) => `Base URL: https://api.libertai.io/v1
-API Key:  YOUR_API_KEY
-Model:    ${model}`,
-	},
-	{
-		name: "OpenCode",
-		description: "Add LibertAI as an OpenAI-compatible provider in ~/.config/opencode/opencode.json.",
-		language: "json",
-		snippet: (model) => `{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "libertai": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "LibertAI",
-      "options": {
-        "baseURL": "https://api.libertai.io/v1",
-        "apiKey": "{env:LIBERTAI_API_KEY}"
-      },
-      "models": {
-        "${model}": {}
-      }
-    }
-  }
-}`,
-	},
-];
 
 export const Route = createFileRoute("/api-keys")({
 	head: () => routeHead("/api-keys"),
@@ -324,7 +271,7 @@ function ApiKeys() {
 			<div className="flex flex-col space-y-8">
 				<PageHeader
 					title="API keys"
-					description="Manage your API keys for LLM inference"
+					description="Manage your API keys and connected devices"
 					action={
 						<Button onClick={() => setShowNewKeyModal(true)}>
 							<Plus className="h-4 w-4 mr-2" />
@@ -461,6 +408,8 @@ function ApiKeys() {
 					</Card>
 				)}
 
+				<CliDevices />
+
 				<Card>
 					<CardHeader title="API usage instructions" icon={<Key className="h-5 w-5 text-primary" />} />
 					<div className="space-y-4 text-card-foreground">
@@ -535,45 +484,6 @@ function ApiKeys() {
 							</a>
 							.
 						</p>
-					</div>
-				</Card>
-
-				<Card>
-					<CardHeader title="Use with your tools" icon={<Settings className="h-5 w-5 text-primary" />} />
-					<p className="text-sm text-muted-foreground mb-4">
-						Drop LibertAI into popular coding agents and IDEs. Snippets update with the selected model above.
-					</p>
-					<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-						{TOOL_INTEGRATIONS.map((tool) => {
-							const snippet = selectedModel ? tool.snippet(selectedModel) : null;
-							return (
-								<div
-									key={tool.name}
-									className="bg-secondary/50 p-4 rounded-md border border-border/50 flex flex-col gap-3"
-								>
-									<div>
-										<h3 className="font-semibold">{tool.name}</h3>
-										<p className="text-xs text-muted-foreground mt-1">{tool.description}</p>
-									</div>
-									<div className="relative">
-										{snippet ? (
-											<>
-												<pre className="text-xs font-mono overflow-x-auto whitespace-pre-wrap bg-background/60 p-3 rounded-md border border-border/50 pr-10">
-													{snippet}
-												</pre>
-												<div className="absolute top-2 right-2">
-													<CopyButton value={snippet} label={`Copy ${tool.name} snippet`} />
-												</div>
-											</>
-										) : isErrorModels ? (
-											<p className="text-sm text-muted-foreground">Snippet unavailable until models load.</p>
-										) : (
-											<Skeleton className="h-24 w-full" />
-										)}
-									</div>
-								</div>
-							);
-						})}
 					</div>
 				</Card>
 			</div>


### PR DESCRIPTION
Adds a "Connected devices" card to the API keys tab listing the machines signed in through `libertai login` — what's connected, when it was last used, and a way to disconnect it. When there are none, the card pitches the CLI inline with install commands.

Frontend half of the feature. The backend shipped in Libertai/libertai-inference#63 and Libertai/libertai-inference#64, both merged and deployed.

## What's here

- **`src/components/CliDevices.tsx`** — the card: rows, disconnect flow, empty-state pitch, install commands.
- **`src/hooks/data/use-cli-keys.ts`** — `GET /api-keys/cli` plus a disconnect mutation on the existing `DELETE /api-keys/{id}`.
- **`src/lib/time.ts`** — UTC-aware date helpers.
- **`src/lib/cli-devices.ts`** — device-name parsing and ordering.
- **`src/components/CodeBlock.tsx`** — `<pre>` + copy button.
- **`src/shared`** pointer bump for the SDK regen (`CliApiKey.last_used_at`).
- The **"Use with your tools"** card is removed.

## Things worth knowing in review

**Timestamps.** Backend `TIMESTAMP` columns are naive UTC serialized without an offset, so a bare `dayjs(value)` reads them as browser-local — a device used a minute ago renders "2 hours ago" at UTC+2. `src/lib/time.ts` exists so `dayjs.utc(v).local()` is written exactly once, and everything new routes through it. Existing bare-`dayjs` sites in `api-keys.tsx` and `usage.tsx` are date-only and left alone; migrating them is a follow-up, not a permanent split.

**"No requests yet", not "Never used".** `last_used_at` only reflects metered inference — `libertai login`, `status` and `keys` leave no trace — so a device connected minutes ago would otherwise read "Never used" right beside a Disconnect button.

**Expiry uses an explicit day count.** dayjs renders roughly 25–46 days all as "a month", which would make the 30-day warning debut as "Expires in a month".

**Disconnect.** Fires the existing idempotent DELETE. The dialog closes immediately, so the pending affordance lives on the row; in-flight ids are tracked as a `Set` rather than a scalar because the shared mutation permits concurrent calls and a scalar re-enabled a still-pending row as soon as a second was started.

**Device labels.** `libertai-cli@<hostname>-<8 hex>` → hostname plus a dim install id. Verified against all nine production key names, including a 32-hex machine-id hostname and a `FLO-MAC-108639-49b23e4b` case that must split at the right hyphen. The pattern is case-sensitive so an uppercase `-DEADBEEF` segment isn't mistaken for an install id.

**LibertAI Desktop mints the same rows** (same code path, same shared config and `device_id`), so the copy is app-neutral rather than CLI-specific.

## Verification

`pnpm build` and `pnpm lint --max-warnings=0` clean. This repo has no test runner, so the parser and comparator were exercised directly against real production key names.

Not yet browser-checked: **the populated list with 2+ devices at ~900px with the sidebar expanded** — the divider spacing under the subtitle, the 32-hex hostname wrapping without pushing the Disconnect button off, and the footer code block not reading as the install command.

## Known, accepted

Removing the tools card drops the only Cursor recipe and the only `https://api.libertai.io` (no `/v1`) reference in the console; both need a home in the docs. A device whose key expired disappears from the list entirely and sees the install pitch, and `libertai logout` doesn't delete the key server-side, so a logged-out machine stays listed until it expires.